### PR TITLE
'Add New Images' feature

### DIFF
--- a/source/Image.py
+++ b/source/Image.py
@@ -6,25 +6,34 @@ from source.Grid import Grid
 import rasterio as rio
 import pandas as pd
 import numpy as np
+import warnings
+
+warnings.filterwarnings("ignore", category=rio.errors.NotGeoreferencedWarning)
+
+
 
 class Image(object):
-    def __init__(self, rect = [0.0, 0.0, 0.0, 0.0],
-        map_px_to_mm_factor = 1.0, width = None, height = None, channels = [], id = None, name = None,
-        acquisition_date = "",
-        georef_filename = "", workspace = [], metadata = {}, annotations = {}, layers = [],
-                 grid = {}, export_dataset_area = []):
+    def __init__(self, rect=[0.0, 0.0, 0.0, 0.0], map_px_to_mm_factor=1.0, width=None, height=None, channels=[],
+                 id=None, name=None, acquisition_date="", georef_filename="", workspace=[], metadata={},
+                 annotations={}, layers=[], grid={}, export_dataset_area=[]):
 
-        #we have to select a standanrd enforced!
-        #in image standard (x, y, width height)
-        #in numpy standard (y, x, height, width) #no the mixed format we use now I REFUSE to use it.
-        #in range np format: (top, left, bottom, right)
-        #in GIS standard (bottom, left, top, right)
+        # Notes:
+        # We have to select a standard to enforce!
+        # In image standard (x, y, width height)
+        # In numpy standard (y, x, height, width); no the mixed format we use now I REFUSE to use it.
+        # In range np format: (top, left, bottom, right)
+        # In GIS standard (bottom, left, top, right)
 
-        self.rect = rect                                         #coordinates of the image. (in the spatial reference system)
-        self.map_px_to_mm_factor = map_px_to_mm_factor           #if we have a references system we should be able to recover this numner
-                                                                # otherwise we need to specify it.
+        # Coordinates of the image (in the spatial reference system)
+        self.rect = rect
+
+        # If we have a references system we should be able to recover this number,
+        # Otherwise we need to specify it.
+        self.map_px_to_mm_factor = map_px_to_mm_factor
+
+        # Dimensions in pixels
         self.width = width
-        self.height = height                                     #in pixels!
+        self.height = height
 
         self.annotations = Annotation()
         for data in annotations:
@@ -42,16 +51,22 @@ class Image(object):
                 layer.shapes.append(shape)
             self.layers.append(layer)
 
-
         self.channels = list(map(lambda c: Channel(**c), channels))
 
-        self.id = id                                    # internal id used in correspondences it will never changes
-        self.name = name                                # a label for an annotated image
-        self.workspace = workspace                      # a polygon in spatial reference system (reserved for future uses)
-        self.export_dataset_area = export_dataset_area  # this is the region exported for training
-        self.acquisition_date = acquisition_date        # acquisition date is mandatory (format YYYY-MM-DD)
-        self.georef_filename = georef_filename          # image file (GeoTiff) contained the georeferencing information
-        self.metadata = metadata                        # this follows image_metadata_template, do we want to allow freedom to add custome values?
+        # Internal id used in correspondences it will never change
+        self.id = id
+        # A label for an annotated image
+        self.name = name
+        # A polygon in spatial reference system (reserved for future uses)
+        self.workspace = workspace
+        # This is the region exported for training
+        self.export_dataset_area = export_dataset_area
+        # Acquisition date is mandatory (format YYYY-MM-DD)
+        self.acquisition_date = acquisition_date
+        # Image file (GeoTiff) contained the geo-referencing information
+        self.georef_filename = georef_filename
+        # This follows image_metadata_template, do we want to allow freedom to add custom values?
+        self.metadata = metadata
 
         if grid:
             self.grid = Grid()
@@ -63,9 +78,15 @@ class Image(object):
         self.cache_labels_table = None
 
     def deleteLayer(self, layer):
+        """
+
+        """
         self.layers.remove(layer)
 
     def pixelSize(self):
+        """
+
+        """
 
         if self.map_px_to_mm_factor == "":
             return 1.0
@@ -74,37 +95,36 @@ class Image(object):
 
     def loadGeoInfo(self, filename):
         """
-        Update the georeferencing information.
+        Update the geo-referencing information.
         """
         img = rio.open(filename)
         if img.crs is not None:
-            # this image contains georeference information
+            # This image contains geo-reference information
             self.georef_filename = filename
-
 
     def addChannel(self, filename, type):
         """
         This image add a channel to this image. The functions update the size (in pixels) and
-        the georeferencing information (if the image if georeferenced).
+        the geo-referencing information (if the image is geo-referenced).
+
         The image data is loaded when the image channel is used for the first time.
         """
 
         img = rio.open(filename)
 
-        # check image size consistency (all the channels must have the same size)
+        # Check image size consistency (all the channels must have the same size)
         if self.width is not None and self.height is not None:
             if self.width != img.width or self.height != img.height:
                 raise Exception("Size of the images is not consistent! It is " + str(img.width) + "x" +
                                 str(img.height) + ", should have been: " + str(self.width) + "x" + str(self.height))
-                return
 
-        # check image size limits
+        # Check image size limits
         if img.width > 32767 or img.height > 32767:
-            raise Exception("This map exceeds the image dimension handled by TagLab (the maximum size is 32767 x 32767).")
-            return
+            raise Exception(
+                "This map exceeds the image dimension handled by TagLab (the maximum size is 32767 x 32767).")
 
         if img.crs is not None:
-            # this image contains georeference information
+            # This image contains geo-reference information
             self.georef_filename = filename
 
         self.width = img.width
@@ -112,11 +132,10 @@ class Image(object):
 
         self.channels.append(Channel(filename, type))
 
-
     def create_labels_table(self, labels):
-        '''
+        """
         Creates a data table for the label panel
-        '''
+        """
 
         if self.annotations.table_needs_update is False:
             return self.cache_labels_table
@@ -126,7 +145,7 @@ class Image(object):
                 'Color': [],
                 'Class': [],
                 '#': np.zeros(len(labels), dtype=np.int32),
-                'Coverage': np.zeros(len(labels),dtype=np.float)
+                'Coverage': np.zeros(len(labels), dtype=np.float)
             }
 
             for i, label in enumerate(labels):
@@ -143,18 +162,17 @@ class Image(object):
             self.annotations.table_needs_update = False
             return df
 
-
     def create_data_table(self):
-        '''
-        This create a data table only for the data panel view
-        '''
+        """
+        This creates a data table only for the data panel view
+        """
 
         if self.annotations.table_needs_update is False:
             return self.cache_data_table
         else:
             scale_factor = self.pixelSize()
 
-            # create a list of instances
+            # Create a list of instances
             name_list = []
             visible_blobs = []
             for blob in self.annotations.seg_blobs:
@@ -169,41 +187,39 @@ class Image(object):
                 'Id': np.zeros(number_of_seg, dtype=np.int32),
                 'Class': [],
                 'Area': np.zeros(number_of_seg),
-                #'Surf. area': np.zeros(number_of_seg)
+                # 'Surf. area': np.zeros(number_of_seg)
             }
 
             for i, blob in enumerate(visible_blobs):
                 dict['Id'][i] = blob.id
                 dict['Class'].append(blob.class_name)
-                dict['Area'][i] = round(blob.area * (scale_factor) * (scale_factor) / 100, 2)
-    #            if blob.surface_area > 0.0:
-    #                dict['Surf. area'][i] = round(blob.surface_area * (scale_factor) * (scale_factor) / 100, 2)
+                dict['Area'][i] = round(blob.area * scale_factor * scale_factor / 100, 2)
 
-            # create dataframe
-            #df = pd.DataFrame(dict, columns=['Id', 'Class', 'Area', 'Surf. area'])
             df = pd.DataFrame(dict, columns=['Id', 'Class', 'Area'])
             self.cache_data_table = df
             self.annotations.table_needs_update = False
+
             return df
 
-
     def updateChannel(self, filename, type):
+        """
+
+        """
         img = rio.open(filename)
 
-        # check image size consistency (all the channels must have the same size)
+        # Check image size consistency (all the channels must have the same size)
         if self.width is not None and self.height is not None:
             if self.width != img.width or self.height != img.height:
                 raise Exception("Size of the images is not consistent! It is " + str(img.width) + "x" +
                                 str(img.height) + ", should have been: " + str(self.width) + "x" + str(self.height))
-                return
 
         if img.crs is not None:
-            # this image contains georeference information
+            # This image contains geo-reference information
             self.georef_filename = filename
 
-        for index,channel in enumerate(self.channels):
+        for index, channel in enumerate(self.channels):
             if channel.type == type:
-               self.channels[index] = Channel(filename, type)
+                self.channels[index] = Channel(filename, type)
 
     def hasDEM(self):
         """
@@ -216,12 +232,18 @@ class Image(object):
         return False
 
     def getChannel(self, type):
+        """
+
+        """
         for channel in self.channels:
             if channel.type == type:
                 return channel
         return None
 
     def getChannelIndex(self, channel):
+        """
+
+        """
         try:
             index = self.channels.index(channel)
             return index

--- a/source/QtImageSettingsWidget.py
+++ b/source/QtImageSettingsWidget.py
@@ -1,0 +1,185 @@
+# TagLab                                               
+# A semi-automatic segmentation tool                                    
+#
+# Copyright(C) 2019                                         
+# Visual Computing Lab                                           
+# ISTI - Italian National Research Council                              
+# All rights reserved.                                                      
+
+# This program is free software; you can redistribute it and/or modify      
+# it under the terms of the GNU General Public License as published by      
+# the Free Software Foundation; either version 2 of the License, or         
+# (at your option) any later version.                                       
+
+# This program is distributed in the hope that it will be useful,           
+# but WITHOUT ANY WARRANTY; without even the implied warranty of            
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the             
+# GNU General Public License (http://www.gnu.org/licenses/gpl.txt)
+# for more details.                                               
+
+import os
+from datetime import datetime
+
+from PyQt5.QtCore import Qt, QSize, pyqtSlot, pyqtSignal
+from PyQt5.QtGui import QImage, QImageReader, QPixmap, QIcon, qRgb, qRed, qGreen, qBlue
+from PyQt5.QtWidgets import QWidget, QMessageBox, QFileDialog, QComboBox, QSizePolicy
+from PyQt5.QtWidgets import QLineEdit, QLabel, QPushButton, QHBoxLayout, QVBoxLayout
+from source import utils
+
+
+class QtImageSettingsWidget(QWidget):
+    accepted = pyqtSignal()
+
+    def __init__(self, parent=None):
+        super(QtImageSettingsWidget, self).__init__(parent)
+
+        self.setStyleSheet("background-color: rgb(40,40,40); color: white")
+
+        self.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
+        self.setMinimumWidth(300)
+        self.setMinimumHeight(100)
+
+        TEXT_SPACE = 100
+
+        self.fields = {
+            "rgb_filenames": {"name": "Image(s):", "value": "", "place": "Path of image(s)", "width": 300,
+                             "action": self.chooseImageFiles},
+            "acquisition_dates": {"name": "Acquisition Date:", "value": "", "place": "YYYY-MM-DD", "width": 150,
+                                 "action": None},
+        }
+        self.data = {}
+
+        layoutV = QVBoxLayout()
+
+        for key, field in self.fields.items():
+            label = QLabel(field["name"])
+            label.setFixedWidth(TEXT_SPACE)
+            label.setAlignment(Qt.AlignRight)
+            label.setMinimumWidth(150)
+
+            edit = QLineEdit(field["value"])
+            edit.setStyleSheet("background-color: rgb(55,55,55); border: 1px solid rgb(90,90,90)")
+            edit.setMinimumWidth(field["width"])
+            edit.setPlaceholderText(field["place"])
+            edit.setMaximumWidth(20)
+            field["edit"] = edit
+
+            button = None
+            if field["action"] is not None:
+                button = QPushButton("...")
+                button.setMaximumWidth(20)
+                button.clicked.connect(field["action"])
+                field["button"] = button
+
+            layout = QHBoxLayout()
+            layout.setAlignment(Qt.AlignLeft)
+            layout.addWidget(label)
+            layout.addWidget(edit)
+            if button is not None:
+                layout.addWidget(button)
+            layout.addStretch()
+            layoutV.addLayout(layout)
+
+        buttons_layout = QHBoxLayout()
+
+        self.btnCancel = QPushButton("Cancel")
+        self.btnCancel.clicked.connect(self.close)
+        self.btnApply = QPushButton("Apply")
+        self.btnApply.clicked.connect(self.accept)
+
+        buttons_layout.setAlignment(Qt.AlignRight)
+        buttons_layout.addStretch()
+        buttons_layout.addWidget(self.btnCancel)
+        buttons_layout.addWidget(self.btnApply)
+
+        ###########################################################
+
+        layoutV.addLayout(buttons_layout)
+        self.setLayout(layoutV)
+
+        self.setWindowTitle("Image Settings")
+        self.setWindowFlags(Qt.Window | Qt.CustomizeWindowHint | Qt.WindowCloseButtonHint | Qt.WindowTitleHint)
+
+    def getNow(self):
+        """
+
+        """
+        # Get the current date and time
+        current_time = datetime.now()
+        return current_time.strftime("%Y-%m-%d")
+
+    def disableRGBloading(self):
+        self.fields["rgb_filenames"]["edit"].setEnabled(False)
+        self.fields["rgb_filenames"]["button"].hide()
+
+    def enableRGBloading(self):
+        self.fields["rgb_filenames"]["edit"].setEnabled(True)
+        self.fields["rgb_filenames"]["button"].show()
+
+    @pyqtSlot()
+    def chooseImageFiles(self):
+        filters = "Image (*.png *.jpg *.jpeg *.tif *.tiff)"
+        fileNames, _ = QFileDialog.getOpenFileNames(self, "Input Image Files", "", filters)
+        if fileNames:
+            joinedFileNames = " ".join(fileNames)
+            self.fields["rgb_filenames"]["edit"].setText(joinedFileNames)
+
+    @pyqtSlot()
+    def accept(self):
+
+        for key, field in self.fields.items():
+            self.data[key] = field["edit"].text()
+
+        # Check validity of the acquisition date
+        acquisition_date = self.data["acquisition_dates"]
+
+        # If none was provided, create one for now
+        if acquisition_date == "":
+            acquisition_date = self.getNow()
+
+        if not utils.isValidDate(acquisition_date):
+            msgBox = QMessageBox()
+            msgBox.setText("Invalid date format. Please, enter the acquisition date as YYYY-MM-DD.")
+            msgBox.exec()
+            return
+
+        # Parse each of the filenames
+        self.data['rgb_filenames'] = self.data['rgb_filenames'].split(" ")
+        rgb_filenames = self.data['rgb_filenames']
+
+        # Update data fields
+        self.data['names'] = []
+        self.data['acquisition_dates'] = []
+        self.data['count'] = 0
+
+        # Loop through each
+        for rgb_filename in rgb_filenames:
+
+            # Check if each of the RGB image file exists
+            if not os.path.exists(rgb_filename):
+                msgBox = QMessageBox()
+                msgBox.setText("The RGB image file does not seems to exist.")
+                msgBox.exec()
+                return
+
+            else:
+                # Set the name, and acquisition date for each of the files
+                self.data['names'].append(".".join(os.path.basename(rgb_filename).split(".")[0:-1]))
+                self.data['acquisition_dates'].append(acquisition_date)
+
+                # Update the count
+                self.data['count'] += 1
+
+        # TODO: redundant check, remove it ?
+        for rgb_filename in rgb_filenames:
+            image_reader = QImageReader(rgb_filename)
+            size = image_reader.size()
+            if size.width() > 32767 or size.height() > 32767:
+                msgBox = QMessageBox()
+                msgBox.setText(f"The image {os.path.basename(rgb_filename)} is too big. "
+                               f"TagLab is limited to 32767x32767 pixels.")
+                msgBox.exec()
+                return
+
+        self.accepted.emit()
+        self.close()


### PR DESCRIPTION
Users can use the "Add New Image(s)..." button in the top panel. It allows users to select multiple file paths instead of just one (like in "Add New Map..."). The file paths are checked to make sure they exist, the name comes from the path base name, and the acquire date is the same for all images; if left blank, it's today's date. Images are created in a loop, where mm_to_pixel variable is just 1.0.